### PR TITLE
Rtl 120 fe 진행중 체크 연동

### DIFF
--- a/src/components/othersTimeline/OthersSubTimelineItem.jsx
+++ b/src/components/othersTimeline/OthersSubTimelineItem.jsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 
-import React, {useState} from "react";
+import React, {useEffect, useState} from "react";
 import {css} from "@emotion/react";
 import styled from 'styled-components';
 import {FiLock, FiUnlock} from "react-icons/fi";
@@ -9,8 +9,23 @@ import {FaRegTrashAlt} from "react-icons/fa";
 import AlertDialog from "../common/AlertDialog";
 import dayjs from "dayjs";
 
-function OthersSubTimelineItem({startDate, endDate, title, isPublic, onClick, isDone, showLine}) {
-  const [isChecked, setIsChecked] = useState(false);
+function OthersSubTimelineItem({ done, startDate, endDate, title, isPublic, onClick, showLine}) {
+  const [isDone, setIsDone] = useState(done); // 진행중 체크
+
+  // 진행중 (isDone) 상태 연동
+  const isDoneStatus =  () => {
+    if (done) { // 상위 컴포넌트에서 서브 타임라인 조회할때 알아내서 그냥 props로 가져옴 (연동코드 굳이 또 쓰지 않음)
+      setIsDone(true)
+      console.log(isDone)
+    } else {
+      setIsDone(false)
+      console.log(isDone)
+    }
+  }
+
+  useEffect(() => {
+    isDoneStatus()
+  }, []);
 
   return (
     <div // 회색 타임라인 박스
@@ -29,7 +44,6 @@ function OthersSubTimelineItem({startDate, endDate, title, isPublic, onClick, is
       })}
     >
       <div // 체크 표시
-        done={isDone}
         css={css`
             width: 21px;
             height: 21px;

--- a/src/components/othersTimeline/OthersSubTimelinePost.jsx
+++ b/src/components/othersTimeline/OthersSubTimelinePost.jsx
@@ -16,7 +16,8 @@ import axiosInstance from "../../utils/axiosInstance";
 
 const label = {inputProps: {'aria-label': 'Checkbox demo'}};
 
-export default function OthersSubTimelinePost({item, isDone}) {
+export default function OthersSubTimelinePost({item}) {
+  const [isDone, setIsDone] = useState(item.done); // 진행중 체크
   const [isLiked, setIsLiked] = useState(false);
   const [isBookmarked, setIsBookmarked] = useState(false);
   const [like, setLike] = useState(item.likeCount); // 좋아요 수
@@ -142,7 +143,6 @@ export default function OthersSubTimelinePost({item, isDone}) {
         })}
       >
         <div // 체크표시
-          done={isDone}
           css={css`
               width: 21px;
               height: 21px;

--- a/src/components/othersTimeline/OthersSubTimelinePost.jsx
+++ b/src/components/othersTimeline/OthersSubTimelinePost.jsx
@@ -48,8 +48,20 @@ export default function OthersSubTimelinePost({item}) {
     }
   }
 
+  // 진행중 (isDone) 상태 연동
+  const isDoneStatus =  () => {
+    if (item.done) { // 상위 컴포넌트에서 서브 타임라인 조회할때 알아내서 그냥 props로 가져옴 (연동코드 굳이 또 쓰지 않음)
+      setIsDone(true)
+      console.log(isDone)
+    } else {
+      setIsDone(false)
+      console.log(isDone)
+    }
+  }
+
   useEffect(() => {
     bookmarkAndLikeStatus();
+    isDoneStatus();
   }, [item])
 
   const onClickLike = async () => {

--- a/src/components/othersTimeline/OthersTimelineItem.jsx
+++ b/src/components/othersTimeline/OthersTimelineItem.jsx
@@ -1,13 +1,29 @@
 /** @jsxImportSource @emotion/react */
 
 import * as React from "react";
-import {useState} from "react";
+import {useEffect, useState} from "react";
 import {css} from "@emotion/react";
 import dayjs from "dayjs";
 import {useNavigate} from "react-router-dom";
 
-export default function OthersTimelineItem({memberId, mainTimelineId, startDate, endDate, title, isDone, showLine}) {
+export default function OthersTimelineItem({memberId, mainTimelineId, startDate, endDate, title, done, showLine}) {
   const navigate = useNavigate();
+  const [isDone, setIsDone] = useState(done); // 진행중 체크
+
+  // 진행중 (isDone) 상태 연동
+  const isDoneStatus =  () => {
+    if (done) { // 상위 컴포넌트에서 메인 타임라인 조회할때 알아내서 그냥 props로 가져옴 (연동코드 굳이 또 쓰지 않음)
+      setIsDone(true)
+      console.log(isDone)
+    } else {
+      setIsDone(false)
+      console.log(isDone)
+    }
+  }
+
+  useEffect(() => {
+    isDoneStatus()
+  }, []);
 
   const handleTitleClick = () => {
     navigate(`/otherssub/${memberId}/${mainTimelineId}`);
@@ -34,7 +50,6 @@ export default function OthersTimelineItem({memberId, mainTimelineId, startDate,
         })}
       >
         <div // 진행중 여부 (체크 표시)
-          done={isDone}
           css={css`
               width: 21px;
               height: 21px;

--- a/src/components/subTimeline/CreateSubTimelinePost.jsx
+++ b/src/components/subTimeline/CreateSubTimelinePost.jsx
@@ -15,7 +15,6 @@ import dayjs from "dayjs";
 const ariaLabel = {'aria-label': 'description'};
 
 export default function CreateSubTimelinePost({post, onCancel, onSubmit}) {
-  const [id, setId] = useState(false);
   const [isChecked, setIsChecked] = useState(false);
   const [startDate, setStartDate] = useState(null);
   const [endDate, setEndDate] = useState(null);
@@ -27,7 +26,6 @@ export default function CreateSubTimelinePost({post, onCancel, onSubmit}) {
   // 수정 모드, 기존 정보 유지 (useEffect)
   useEffect(() => {
     if (post) {
-      setId(post.id)
       setStartDate(post.startDate);
       setEndDate(post.endDate);
       setTitle(post.title);
@@ -42,7 +40,6 @@ export default function CreateSubTimelinePost({post, onCancel, onSubmit}) {
       setAlertOpen(true);
     } else {
       const newSubItem = {
-        id,
         startDate: dayjs(startDate).format("YYYY-MM-DD"),
         endDate: endDate ? dayjs(endDate).format("YYYY-MM-DD") : null,
         title,

--- a/src/components/subTimeline/CreateSubTimelinePost.jsx
+++ b/src/components/subTimeline/CreateSubTimelinePost.jsx
@@ -15,6 +15,7 @@ import dayjs from "dayjs";
 const ariaLabel = {'aria-label': 'description'};
 
 export default function CreateSubTimelinePost({post, onCancel, onSubmit}) {
+  const [id, setId] = useState(false);
   const [isChecked, setIsChecked] = useState(false);
   const [startDate, setStartDate] = useState(null);
   const [endDate, setEndDate] = useState(null);
@@ -26,6 +27,7 @@ export default function CreateSubTimelinePost({post, onCancel, onSubmit}) {
   // 수정 모드, 기존 정보 유지 (useEffect)
   useEffect(() => {
     if (post) {
+      setId(post.id)
       setStartDate(post.startDate);
       setEndDate(post.endDate);
       setTitle(post.title);
@@ -40,6 +42,7 @@ export default function CreateSubTimelinePost({post, onCancel, onSubmit}) {
       setAlertOpen(true);
     } else {
       const newSubItem = {
+        id,
         startDate: dayjs(startDate).format("YYYY-MM-DD"),
         endDate: endDate ? dayjs(endDate).format("YYYY-MM-DD") : null,
         title,

--- a/src/components/subTimeline/ReadSubTimelinePost.jsx
+++ b/src/components/subTimeline/ReadSubTimelinePost.jsx
@@ -18,7 +18,7 @@ import axiosInstance from "../../utils/axiosInstance";
 const label = {inputProps: {'aria-label': 'Checkbox demo'}};
 
 export default function ReadSubTimelinePost({item, onDelete, onEdit}) {
-  const [isChecked, setIsChecked] = useState(false); // 타임라인 체크 circle 상태
+  const [isDone, setIsDone] = useState(item.done); // 진행중 체크
   const [isLiked, setIsLiked] = useState(false);
   const [isBookmarked, setIsBookmarked] = useState(false);
   const [like, setLike] = useState(item.likeCount); // 좋아요 수
@@ -49,8 +49,20 @@ export default function ReadSubTimelinePost({item, onDelete, onEdit}) {
     }
   }
 
+  // 진행중 (isDone) 상태 연동
+  const isDoneStatus =  () => {
+    if (item.done) { // 상위 컴포넌트에서 서브 타임라인 조회할때 알아내서 그냥 props로 가져옴 (연동코드 굳이 또 쓰지 않음)
+      setIsDone(true)
+      console.log(isDone)
+    } else {
+      setIsDone(false)
+      console.log(isDone)
+    }
+  }
+
   useEffect(() => {
     bookmarkAndLikeStatus();
+    isDoneStatus();
   }, [item])
 
   const onClickLike = async () => {
@@ -88,6 +100,31 @@ export default function ReadSubTimelinePost({item, onDelete, onEdit}) {
       }
     }
     setIsLiked(!isLiked); // 좋아요 상태 토글
+  }
+
+  // 진행중 (isDone) 연동
+  const onClickIsDone = async () => {
+    if (isDone) {
+      // 체크 해제 연동
+      try {
+        const response = await axiosInstance.put(`/api/v1/sub-timelines/${item.id}/toggle-done`);
+        setIsDone(false);
+        console.log("진행중 체크 해제 완료", response);
+      } catch (error) {
+        console.log("진행중 체크 해제 오류", error);
+        console.error("에러 상세:", error.response ? error.response.data : error.message);
+      }
+    } else {
+      // 체크 연동
+      try {
+        const response = await axiosInstance.put(`/api/v1/sub-timelines/${item.id}/toggle-done`);
+        setIsDone(true);
+        console.log("진행중 체크 완료", response)
+      } catch (error) {
+        console.log("진행중 체크 오류", error);
+        console.error("에러 상세:", error.response ? error.response.data : error.message);
+      }
+    }
   }
 
   const onClickBookmark = async () => {
@@ -145,8 +182,7 @@ export default function ReadSubTimelinePost({item, onDelete, onEdit}) {
           })}
         >
           <div // 체크표시
-            done={isChecked}
-            onClick={() => setIsChecked(!isChecked)}
+            onClick={onClickIsDone}
             css={css`
                 width: 21px;
                 height: 21px;
@@ -158,7 +194,7 @@ export default function ReadSubTimelinePost({item, onDelete, onEdit}) {
                 margin-left: 35px;
                 margin-right: 15px;
                 cursor: pointer;
-                background-color: ${isChecked ? "#829FD7" : "#f8f6f6"}; // 선 때문에 뚫린 원일 때도 배경 색 설정
+                background-color: ${isDone ? "#829FD7" : "#f8f6f6"}; // 선 때문에 뚫린 원일 때도 배경 색 설정
             `}
           />
           <div // 기간

--- a/src/components/subTimeline/SubTimelineItem.jsx
+++ b/src/components/subTimeline/SubTimelineItem.jsx
@@ -1,16 +1,54 @@
 /** @jsxImportSource @emotion/react */
 
-import React, {useState} from "react";
+import React, {useEffect, useState} from "react";
 import {css} from "@emotion/react";
-import styled from 'styled-components';
 import {FiLock, FiUnlock} from "react-icons/fi";
-import {GoPencil} from "react-icons/go";
-import {FaRegTrashAlt} from "react-icons/fa";
 import AlertDialog from "../common/AlertDialog";
 import dayjs from "dayjs";
+import axiosInstance from "../../utils/axiosInstance";
 
-function SubTimelineItem({startDate, endDate, title, isPublic, onClick, showLine}) {
-  const [isChecked, setIsChecked] = useState(false);
+function SubTimelineItem({subTimelineId, startDate, endDate, title, done, isPublic, onClick, showLine}) {
+  const [isDone, setIsDone] = useState(done); // 진행중 체크
+
+  // 진행중 (isDone) 연동
+  const onClickIsDone = async () => {
+    if (isDone) {
+      // 체크 해제 연동
+      try {
+        const response = await axiosInstance.put(`/api/v1/sub-timelines/${subTimelineId}/toggle-done`);
+        setIsDone(false);
+        console.log("진행중 체크 해제 완료", response);
+      } catch (error) {
+        console.log("진행중 체크 해제 오류", error);
+        console.error("에러 상세:", error.response ? error.response.data : error.message);
+      }
+    } else {
+      // 체크 연동
+      try {
+        const response = await axiosInstance.put(`/api/v1/sub-timelines/${subTimelineId}/toggle-done`);
+        setIsDone(true);
+        console.log("진행중 체크 완료", response)
+      } catch (error) {
+        console.log("진행중 체크 오류", error);
+        console.error("에러 상세:", error.response ? error.response.data : error.message);
+      }
+    }
+  }
+
+  // 진행중 (isDone) 상태 연동
+  const isDoneStatus =  () => {
+    if (done) { // 상위 컴포넌트에서 서브 타임라인 조회할때 알아내서 그냥 props로 가져옴 (연동코드 굳이 또 쓰지 않음)
+      setIsDone(true)
+      console.log(isDone)
+    } else {
+      setIsDone(false)
+      console.log(isDone)
+    }
+  }
+
+  useEffect(() => {
+    isDoneStatus()
+  }, []);
 
   return (
     <div // 회색 타임라인 박스
@@ -29,8 +67,7 @@ function SubTimelineItem({startDate, endDate, title, isPublic, onClick, showLine
       })}
     >
       <div // 체크 표시
-        done={isChecked}
-        onClick={() => setIsChecked(!isChecked)}
+        onClick={onClickIsDone}
         css={css`
             width: 21px; // 21px
             height: 21px; // 21px
@@ -42,7 +79,7 @@ function SubTimelineItem({startDate, endDate, title, isPublic, onClick, showLine
             margin-left: 30px;
             margin-right: 15px;
             cursor: pointer;
-            background-color: ${isChecked ? "#829FD7" : "#f8f6f6"}; // 선 때문에 뚫린 원일 때도 배경 색 설정
+            background-color: ${isDone ? "#829FD7" : "#f8f6f6"}; // 선 때문에 뚫린 원일 때도 배경 색 설정
         `}
       />
       <div

--- a/src/components/timeline/MainTimelineItem.jsx
+++ b/src/components/timeline/MainTimelineItem.jsx
@@ -1,6 +1,6 @@
 /** @jsxImportSource @emotion/react */
 
-import React, {useState} from "react";
+import React, {useEffect, useState} from "react";
 import {css} from "@emotion/react";
 import {FiLock, FiUnlock} from "react-icons/fi";
 import {GoPencil} from "react-icons/go";
@@ -10,9 +10,9 @@ import dayjs from 'dayjs';
 import { useNavigate } from 'react-router-dom';
 import axiosInstance from "../../utils/axiosInstance";
 
-function MainTimelineItem({mainTimelineId, startDate, endDate, title, onEdit, onDelete, showLine}) {
+function MainTimelineItem({mainTimelineId, startDate, endDate, title, done, onEdit, onDelete, showLine}) {
   const navigate = useNavigate();
-  const [isDone, setIsDone] = useState(false); // 진행중 체크
+  const [isDone, setIsDone] = useState(done); // 진행중 체크
 
   const handleTitleClick = () => {
     // navigate(`/subtimeline/${mainTimelineId}`, { state: { title } });
@@ -43,6 +43,21 @@ function MainTimelineItem({mainTimelineId, startDate, endDate, title, onEdit, on
       }
     }
   }
+
+  // 진행중 (isDone) 상태 연동
+  const isDoneStatus =  () => {
+    if (done) { // 상위 컴포넌트에서 메인 타임라인 조회할때 알아내서 그냥 props로 가져옴 (연동코드 굳이 또 쓰지 않음)
+      setIsDone(true)
+      console.log(isDone)
+    } else {
+      setIsDone(false)
+      console.log(isDone)
+    }
+  }
+
+  useEffect(() => {
+    isDoneStatus()
+  }, []);
 
   return (
     <div // 회색 타임라인 박스

--- a/src/components/timeline/MainTimelineItem.jsx
+++ b/src/components/timeline/MainTimelineItem.jsx
@@ -8,15 +8,41 @@ import {FaRegTrashAlt} from "react-icons/fa";
 import AlertDialog from "../common/AlertDialog";
 import dayjs from 'dayjs';
 import { useNavigate } from 'react-router-dom';
+import axiosInstance from "../../utils/axiosInstance";
 
 function MainTimelineItem({mainTimelineId, startDate, endDate, title, onEdit, onDelete, showLine}) {
-  const [isChecked, setIsChecked] = useState(false);
   const navigate = useNavigate();
+  const [isDone, setIsDone] = useState(false); // 진행중 체크
 
   const handleTitleClick = () => {
     // navigate(`/subtimeline/${mainTimelineId}`, { state: { title } });
     navigate(`/subtimeline/${mainTimelineId}`);
   };
+
+  // 진행중 (isDone) 연동
+  const onClickIsDone = async () => {
+    if (isDone) {
+      // 체크 해제 연동
+      try {
+        const response = await axiosInstance.put(`/api/v1/main-timelines/${mainTimelineId}/toggle-done`);
+        setIsDone(false);
+        console.log("진행중 체크 해제 완료", response);
+      } catch (error) {
+        console.log("진행중 체크 해제 오류", error);
+        console.error("에러 상세:", error.response ? error.response.data : error.message);
+      }
+    } else {
+      // 체크 연동
+      try {
+        const response = await axiosInstance.put(`/api/v1/main-timelines/${mainTimelineId}/toggle-done`);
+        setIsDone(true);
+        console.log("진행중 체크 완료", response)
+      } catch (error) {
+        console.log("진행중 체크 오류", error);
+        console.error("에러 상세:", error.response ? error.response.data : error.message);
+      }
+    }
+  }
 
   return (
     <div // 회색 타임라인 박스
@@ -35,8 +61,7 @@ function MainTimelineItem({mainTimelineId, startDate, endDate, title, onEdit, on
       })}
     >
       <div // 체크표시
-        done={isChecked}
-        onClick={() => setIsChecked(!isChecked)}
+        onClick={onClickIsDone}
         css={css`
             width: 22px;
             height: 22px;
@@ -48,7 +73,7 @@ function MainTimelineItem({mainTimelineId, startDate, endDate, title, onEdit, on
             margin-top: 31px;
             margin-left: 40px;
             cursor: pointer;
-            background-color: ${isChecked ? "#829FD7" : "none"};
+            background-color: ${isDone ? "#829FD7" : "none"};
         `}
       />
       <div // 기간

--- a/src/components/timeline/MainTimelineItem.jsx
+++ b/src/components/timeline/MainTimelineItem.jsx
@@ -15,7 +15,6 @@ function MainTimelineItem({mainTimelineId, startDate, endDate, title, done, onEd
   const [isDone, setIsDone] = useState(done); // 진행중 체크
 
   const handleTitleClick = () => {
-    // navigate(`/subtimeline/${mainTimelineId}`, { state: { title } });
     navigate(`/subtimeline/${mainTimelineId}`);
   };
 

--- a/src/pages/MainTimeline.jsx
+++ b/src/pages/MainTimeline.jsx
@@ -190,6 +190,7 @@ export default function MainTimeline() {
               startDate={item.data.startDate}
               endDate={item.data.endDate}
               title={item.data.title}
+              done={item.data.done}
               onEdit={() => editItem(index)}
               onDelete={() => deleteItem(index)}
               showLine={index !== items.length - 1} // 마지막 아이템에는 선을 표시하지 않음

--- a/src/pages/MainTimeline.jsx
+++ b/src/pages/MainTimeline.jsx
@@ -44,16 +44,7 @@ export default function MainTimeline() {
     const itemId = items[index].data.id;
     // 메인 타임라인 삭제 연동 (DEL, DELETE)
     try {
-      await axios.delete(
-        `/api/v1/main-timelines/${itemId}`,
-        {
-          headers: {
-            Accept: "*/*",
-            "Content-Type": `application/json`,
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      );
+      await axiosInstance.delete(`/api/v1/main-timelines/${itemId}`);
       setItems(items.filter((_, i) => i !== index));
       console.log("메인 타임라인 삭제 완료");
     } catch (error) {
@@ -88,15 +79,7 @@ export default function MainTimeline() {
     // 내 프로필 조회 연동 (메인 타임라인 페이지 내)
     const fetchProfile = async () => {
       try {
-        const response = await axios.get(
-          `/api/v1/my-profile`,
-          {
-            headers: {
-              Accept: "*/*",
-              "Content-Type": "application/json",
-              Authorization: `Bearer ${token}`,
-            },
-          });
+        const response = await axiosInstance.get(`/api/v1/my-profile`);
         setProfile(response.data);
         console.log("프로필 조회 완료", response);
 
@@ -111,16 +94,7 @@ export default function MainTimeline() {
     // 메인 타임라인 조회 연동 (GET, READ)
     const fetchMainTimelines = async (memberId) => {
       try {
-        const response = await axios.get(
-          `/api/v1/main-timelines/member/${memberId}`,
-          {
-            headers: {
-              Accept: "*/*",
-              "Content-Type": `application/json`,
-              Authorization: `Bearer ${token}`,
-            },
-          }
-        );
+        const response = await axiosInstance.get(`/api/v1/main-timelines/member/${memberId}`);
         setItems(response.data.map(item => ({ type: "item", data: item })));
         console.log("메인 타임라인 조회 완료", response);
       } catch (error) {
@@ -142,20 +116,13 @@ export default function MainTimeline() {
     // 메인 타임라인 수정 연동 (PUT, UPDATE)
     console.log(items);
     try {
-      const response = await axios.put( // 서버에 put 요청 보냄
+      const response = await axiosInstance.put( // 서버에 put 요청 보냄
         `/api/v1/main-timelines/${itemId}`,
         {
           title: data.title,
           startDate: data.startDate,
           endDate: data.endDate,
         },
-        {
-          headers: {
-            Accept: "*/*",
-            "Content-Type": `application/json`,
-            Authorization: `Bearer ${token}`,
-          },
-        }
       );
       const newItems = items.slice();
       newItems[index] = { type: "item", data: response.data };

--- a/src/pages/OthersMainTimeline.jsx
+++ b/src/pages/OthersMainTimeline.jsx
@@ -76,7 +76,7 @@ export default function OthersMainTimeline() {
             startDate={item.data.startDate}
             endDate={item.data.endDate}
             title={item.data.title}
-            isDone={item.isDone}
+            done={item.data.done}
             showLine={index !== items.length - 1} // 마지막 아이템에는 선을 표시하지 않음
           />
         ))}

--- a/src/pages/OthersSubTimeline.jsx
+++ b/src/pages/OthersSubTimeline.jsx
@@ -18,7 +18,6 @@ export default function OthersSubTimeline() {
   const [title, setTitle] = useState( "메인 타임라인 제목");
   const [profile, setProfile] = useState(null); // 프로필 상태 추가
 
-  const [isDone, setIsDone] = useState(false);
   const [subTimelineItems, setSubTimelineItems] = useState([]);
   const [selectedItem, setSelectedItem] = useState(null);
 
@@ -97,7 +96,6 @@ export default function OthersSubTimeline() {
         >
           {selectedItem && (
             <OthersSubTimelinePost
-              isDone={true}
               item={selectedItem}
             />
           )}
@@ -127,6 +125,7 @@ export default function OthersSubTimeline() {
               startDate={item.startDate}
               endDate={item.endDate}
               title={item.title}
+              done={item.done}
               isPublic={item.isPublic}
               onClick={() => handleSelectItem(item)}
               showLine={index !== subTimelineItems.length - 1} // 마지막 아이템에는 선을 표시하지 않음

--- a/src/pages/SubTimeline.jsx
+++ b/src/pages/SubTimeline.jsx
@@ -7,14 +7,12 @@ import CreateSubTimelinePost from "../components/subTimeline/CreateSubTimelinePo
 import ReadSubTimelinePost from "../components/subTimeline/ReadSubTimelinePost";
 import SubTimelineItem from "../components/subTimeline/SubTimelineItem";
 import Button from "../components/common/Button";
-import axios from "axios";
 import {useParams, useLocation, useSearchParams} from 'react-router-dom';
 import axiosInstance from "../utils/axiosInstance";
 import Header from "../components/common/Header";
 
 export default function SubTimeline() {
   const {mainTimelineId} = useParams(); // URL 파라미터로부터 id 받아오기
-  const location = useLocation(); // 토큰 때문에 필요한 거인듯 (연동할때) -> 연동 코드 바꾸기 by axiosInstance
   const [searchParams, setSearchParams] = useSearchParams(); // 쿼리 스트링의 value를 가져오기 위함
   const targetId = searchParams.get("subtimelineId") // 타겟 서브타임라인 id
 
@@ -119,6 +117,10 @@ export default function SubTimeline() {
 
         console.log("서브 타임라인 수정 완료", response.data)
         console.log(subTimelineItems);
+
+        // 수정 후 서브 타임라인 다시 조회
+        await fetchSubTimelines();
+        setSelectedItem(newItem);
       } catch (error) {
         console.log("서브 타임라인 수정 에러: ", error);
         console.error("에러 상세:", error.response ? error.response.data : error.message);
@@ -144,6 +146,10 @@ export default function SubTimeline() {
 
         console.log("서브 타임라인 생성 완료", response.data)
         console.log(subTimelineItems);
+
+        // 생성 후 서브 타임라인 다시 조회
+        await fetchSubTimelines();
+        setSelectedItem(newItem);
       } catch (error) {
         console.log("서브 타임라인 생성 에러: ", error);
         console.error("에러 상세:", error.response ? error.response.data : error.message);
@@ -168,6 +174,9 @@ export default function SubTimeline() {
       }
       console.log("서브 타임라인 삭제 완료");
       console.log(subTimelineItems);
+
+      // 삭제 후 서브 타임라인 다시 조회
+      fetchSubTimelines();
     } catch (error) {
       console.error("서브 타임라인 삭제 에러 발생:", error.response ? error.response.data : error.message);
     }

--- a/src/pages/SubTimeline.jsx
+++ b/src/pages/SubTimeline.jsx
@@ -62,7 +62,7 @@ export default function SubTimeline() {
   };
 
   // 서브 타임라인 조회 연동
-  const fetchSubTimelines = async () => {
+  const fetchSubTimelines = async (newItemId) => {
     try {
       const response = await axiosInstance.get(
         `/api/v1/sub-timelines/main/${mainTimelineId}/ordered`, // 메인 타임라인 ID로 서브 타임라인 데이터 가져오기
@@ -70,7 +70,8 @@ export default function SubTimeline() {
       const data = response.data.subTimelines;
       setSubTimelineItems(data);
 
-      const targetIndex = data.findIndex(item => item.id.toString() === targetId);
+      const targetIndex = data.findIndex(item => item.id.toString() === targetId); // 쿼리문에서 받은 서브 타임라인 ID와 일치하는 인덱스 찾기
+      const targetIndex2 = data.findIndex(item => item.id === newItemId); // 새로 생성(수정) 서브 타임라인 ID와 일피하는 인덱스 찾기
 
       if (targetIndex !== -1) {
         setSelectedItem(data[targetIndex]); // 해당 id를 가진 아이템이 있으면 그 아이템을 선택
@@ -80,6 +81,10 @@ export default function SubTimeline() {
       } else {
         setIsCreating(true)
         // +) 서브 타임라인이 하나도 없는 경우 -> ui 디자인 해야 함
+      }
+
+      if (targetIndex2 !== -1) {
+        setSelectedItem(data[targetIndex2]); // 해당 id를 가진 아이템이 있으면 그 아이템을 선택
       }
 
       setTitle(response.data.mainTimelineTitle)
@@ -119,8 +124,7 @@ export default function SubTimeline() {
         console.log(subTimelineItems);
 
         // 수정 후 서브 타임라인 다시 조회
-        await fetchSubTimelines();
-        setSelectedItem(newItem);
+        await fetchSubTimelines(editablePost.id);
       } catch (error) {
         console.log("서브 타임라인 수정 에러: ", error);
         console.error("에러 상세:", error.response ? error.response.data : error.message);
@@ -147,9 +151,11 @@ export default function SubTimeline() {
         console.log("서브 타임라인 생성 완료", response.data)
         console.log(subTimelineItems);
 
+        const createdItemId = response.data.subTimelineId; // 새로 생성된 타임라인의 id
+        console.log(createdItemId)
+
         // 생성 후 서브 타임라인 다시 조회
-        await fetchSubTimelines();
-        setSelectedItem(newItem);
+        await fetchSubTimelines(createdItemId);
       } catch (error) {
         console.log("서브 타임라인 생성 에러: ", error);
         console.error("에러 상세:", error.response ? error.response.data : error.message);
@@ -176,7 +182,7 @@ export default function SubTimeline() {
       console.log(subTimelineItems);
 
       // 삭제 후 서브 타임라인 다시 조회
-      fetchSubTimelines();
+      // fetchSubTimelines(); 이거 있으면 위에 selectedItem 설정해놓은게 적용이 안됨 초기화 돼서
     } catch (error) {
       console.error("서브 타임라인 삭제 에러 발생:", error.response ? error.response.data : error.message);
     }

--- a/src/pages/SubTimeline.jsx
+++ b/src/pages/SubTimeline.jsx
@@ -19,8 +19,6 @@ export default function SubTimeline() {
   const [title, setTitle] = useState("메인 타임라인 제목");
   const [profile, setProfile] = useState(null); // 프로필 상태 추가
 
-  const [isDone, setIsDone] = useState(false); // 체크를 사용자가 직접 체크 안할 경우
-  const [isChecked, setIsChecked] = useState(false); // 사용자가 직접 체크 할 경우
   const [isCreating, setIsCreating] = useState(false);
   const [editablePost, setEditablePost] = useState(null);
   const [subTimelineItems, setSubTimelineItems] = useState([]); // 타임라인 항목들을 관리할 상태 생성
@@ -254,9 +252,11 @@ export default function SubTimeline() {
         {subTimelineItems.map((item, index) => (
           <SubTimelineItem
             key={index}
+            subTimelineId={item.id}
             startDate={item.startDate}
             endDate={item.endDate}
             title={item.title}
+            done={item.done}
             isPublic={item.isPublic}
             onClick={() => handleSelectItem(item)}
             showLine={index !== subTimelineItems.length - 1} // 마지막 아이템에는 선을 표시하지 않음


### PR DESCRIPTION
- 메인 타임라인 isDone (진행중 여부) 토글 기능 연동
- 메인 타임라인 isDone 상태 연동 완료 (상태 유지 in front)
- 서브 타임라인 아이템 isDone 토글 기능 연동
- 서브 타임라인 아이템 isDone 상태 연동 (상태 유지)
- 서브 타임라인 포스트 isDone 토글 기능, 상태 연동
- 다른 사용자 메인 타임라인 isDone 상태 연동 (조회)
- 다른 사용자 서브 타임라인 isDone 상태 연동 (조회)
---
현재 문제점
- 타임라인 생성(수정)할 때부터 진행중 상태 받아서 서버에 저장하는 것 해야함 (post, put할때 body에 진행 중 여부 같이 보내야 함, 이와 비슷한 맥락으로 공개/비공개도 같이 넣어야 함)
- 서브 타임라인 ReadPost, CreatePost, item 이 세가지 컴포넌트 간의  동기화 필요 (진행중 버튼을 딱 누르는 시점에서의 동기화)

---
[메인 타임라인 리팩토링 (메인 타임라인 버그 해결 브랜치에 포함)]
- 메인 타임라인 연동 axios --> axiosInstance로 모두 변경
- 메인 타임라인 생성, 수정 하자마자 바로 삭제, 수정 안되는 문제 해결

[서브 타임라인 리팩토링 (서브 타임라인 버그 해결 브랜치에 포함)]
- 서브 타임라인 연동 axios --> axiosInstance로 모두 변경
- 서브 타임라인 코드 순서 바꿈
- 서브 타임라인 생성/수정 하자마자 바로 삭제, 수정 안되는 문제 해결
- 서브 타임라인 생성/수정 후 해당 포스트에 좋아요/북마크 수 바로 연결